### PR TITLE
Upgrade application dependencies on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:14 as build
+FROM node:16 as build
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm ci --only=production
 
-FROM node:14-alpine@sha256:b2da3316acdc2bec442190a1fe10dc094e7ba4121d029cb32075ff59bb27390a
+FROM node:16-alpine@sha256:a9b9cb880fa429b0bea899cd3b1bc081ab7277cc97e6d2dcd84bd9753b2027e1
 
 # ===== Fix any security vulnerability according to Snyk ===
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     apk update && \
     apk add --no-cache \
-    apk-tools=2.12.7-r3
+    apk-tools~=2.12
 # hadolint disable=DL3059
 RUN apk add --no-cache \
-    dumb-init=1.2.2-r1 \
-    libcrypto1.1=1.1.1l-r4 \
-    busybox=1.31.1-r10 
+    dumb-init~=1.2 \
+    libcrypto1.1~=1.1 \
+    busybox~=1.33 
 # ============================================================
 
 ENV NODE_ENV production


### PR DESCRIPTION
- Upgrade Node version
- Upgrade Busybox version for Alpine distributions
- Remove hard-lock on Alpine versions (only interested on med. changes)

Apparently Alpine has a really strict policy for the version retrieval, as mentioned on the [discussion in the Hadolint project](https://github.com/hadolint/hadolint/issues/204).

Best solution, is to fix up until the minor version and ignore the patch and lower identifiers as pre-release or build.

Also, since **Node 14** isn't active and it [entered on Maintenance phase](https://nodejs.org/en/about/releases/), I consider important to change the base images to **Node 16** for two reasons:

- First, because an active LTS will have more and faster bugfixes, as well more attention (both from maintainers and community) in finding possible security issues.
- Second, because the **Node 14** images are using **Alpine 3.11.7**, which is no longer supported by the Alpine maintainers, and it's not worth it the effort of creating a custom image for **Node 14** on **Alpine 3.14**.

Finally, the upgrade on `busybox` is due to a major version change on that dependency for **Alpine 3.14**.

This could be considered a minor change, since as mentioned by @upkarlidder on Slack, we shouldn't be tied on any **Node 14** dependency.

Resolves: https://github.com/Pyrrha-Platform/Pyrrha-MQTT-Client/issues/35
