### PR TITLE
fix - wrap iot-2/# in single quotes - overcomes docker parse special chars issue

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,5 +1,5 @@
 IOT_HOST=pyrrha-mqttserver
-IOT_TOPIC=iot-2/#
+IOT_TOPIC='iot-2/#'
 IOT_PROTOCOL=mqtt
 IOT_PORT=1883
 IOT_SECURE_PORT=1883


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
Docker sometimes incorrectly parses "special" characters when parsing the environment variables in the `.env.docker` file. In this case it was incorrectly parsing `#`. So by wrapping ` iot-2/#` in single quotes (`'iot-2/#'`), it can’t get misinterpreted when parsing.

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
None